### PR TITLE
fix: fix range too wide errors triggered after the scanner has been running for a while

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,7 @@ use ethers::types::Log;
 
 use crate::chain_config::ChainConfig;
 
+#[derive(Debug)]
 pub enum Update {
     NewBlock(u64),
     NewLog(Log),


### PR DESCRIPTION
If an error happened after the present scanner had been running for a while, the error was logged and the broken stream restarted indefinitely through a `loop`. The issue arose because the original starting block number was used to perform the first get logs request after each error-caused restart, causing a loop of range too wide errors without end. This PR addresses it by keeping an up to date block number in memory that will be used as a new starting block in case an error happens and the scanning stream has to be restarted.